### PR TITLE
Feat: stockprice history database update and add dashboard using plotly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 
 # 프로젝트 외 출력물
 *.mwb
+
+# configuration file
+config.py

--- a/api/admin.py
+++ b/api/admin.py
@@ -1,5 +1,4 @@
 #  file: api/admin.py
-from csv import list_dialects
 from django.contrib import admin
 
 from api.models import StockList, StockInformationHistory, StockPriceHistory

--- a/api/models.py
+++ b/api/models.py
@@ -1,8 +1,6 @@
 #  file: api/models.py
 
 
-from tabnanny import verbose
-from turtle import update
 from django.db import models
 from django.urls import reverse
 from datetime import datetime

--- a/api/models.py
+++ b/api/models.py
@@ -80,7 +80,7 @@ class StockInformationHistory(models.Model):
     create_dt = models.DateTimeField(verbose_name='create_dt', auto_now_add=True)
 
     class Meta:
-        ordering = ['-update_date', 'ticker']
+        ordering = ['ticker','-update_date']
 
     def __str__(self): 
         return str(self.id)
@@ -89,7 +89,7 @@ class StockInformationHistory(models.Model):
     #     return reverse('stock_information_history-detail', args=(self.ticker))
 
 class StockPriceHistory(models.Model): 
-    """ 종목의 상장 이후 부터 현재까지 주가 히스토리
+    """ 종목의 상장 이후 부터 현재까지 주가 히스토리, 히스토리 간격(interval): 1day
     pk = "id"
     columns = ["ticker", "update_date", "price_open", "price_high", "price_low", "price_close"
     , "adj_close", "volume", "splits", "dividends", "update_dt", "create_dt"]
@@ -100,11 +100,10 @@ class StockPriceHistory(models.Model):
     update_date = models.DateField(help_text='날짜', default=datetime.today)
     
     price_open = models.FloatField(blank=True, null=True, help_text="시가")
-    price_high = models.FloatField(default=0, help_text="고가")
-    price_low = models.FloatField(default=0, help_text="저가")
-    price_close = models.FloatField(blank=True, null=True ,help_text="종가")
-    adj_close = models.FloatField(blank=True, null=True, help_text="조정 종가")
-    volume = models.FloatField(default=0, help_text="거래량")
+    price_high = models.FloatField(blank=True, null=True, help_text="고가")
+    price_low = models.FloatField(blank=True, null=True, help_text="저가")
+    price_close = models.FloatField(help_text="종가")
+    volume = models.FloatField(blank=True, null=True, help_text="거래량")
 
     splits = models.FloatField(blank=True, null=True, help_text='주식분할 내역')
     dividends = models.FloatField(blank=True, null=True, help_text='배당 내역')
@@ -113,9 +112,9 @@ class StockPriceHistory(models.Model):
     create_dt = models.DateTimeField(verbose_name='create_dt', auto_now_add=True)
 
     class Meta:
-        ordering = ['-update_date', 'ticker']
+        ordering = ['ticker', '-update_date' ]
     
     def __str__(self): 
-        return str(self.id)
+        return str(self.ticker) + "@" + str(self.update_date)
 
     

--- a/backend/settings/develop.py
+++ b/backend/settings/develop.py
@@ -1,6 +1,7 @@
 #  file: backend/settings/develop.py
 
 from .base import *
+from config import db_config
 
 SECRET_KEY = 'django-insecure-n2hnn=ggfzp4i2(ed-$rlf_ovsdu@v9ie!3-%*g!=bs-lqhu0x'
 DEBUG = True
@@ -11,7 +12,7 @@ DATABASES = {
         'ENGINE': 'django.db.backends.mysql',
         'NAME': 'oruum_db',
         'USER': 'root',
-        'PASSWORD': '3102',
+        'PASSWORD': db_config["password"],
         'HOST': '127.0.0.1',
         'PORT': '3306',
     }

--- a/backend/settings/develop.py
+++ b/backend/settings/develop.py
@@ -1,11 +1,11 @@
 #  file: backend/settings/develop.py
 
 from .base import *
-from config import db_config
+from config import db_config, django_config
 
-SECRET_KEY = 'django-insecure-n2hnn=ggfzp4i2(ed-$rlf_ovsdu@v9ie!3-%*g!=bs-lqhu0x'
+SECRET_KEY = django_config["SECRET_KEY"]
 DEBUG = True
-ALLOWED_HOSTS = [] # blank means 'localhost', '127.0.0.1'
+ALLOWED_HOSTS = ['*'] # blank means 'localhost', '127.0.0.1'
 
 DATABASES = {
     'default': {

--- a/dashboard/plotly_set.py
+++ b/dashboard/plotly_set.py
@@ -1,42 +1,34 @@
 #  file: dashboard/plotly_set.py
 
-
 import pandas as pd
-import pymysql.cursors
 from plotly.offline import plot
 import plotly.graph_objs as go
-from os import name
 import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input, Output
 from django_plotly_dash import DjangoDash
+from api.models import StockPriceHistory, StockList
+import plotly.express as px
 
-
-def plot_plotly(mysql_connection):
+def plot_plotly(ticker):
     """
     This function plots plotly plot
     """
-    #Create SQL command string
-    sql = """SELECT * FROM api_stock_list"""
 
-    #Get table from SQL result
-    with mysql_connection.cursor() as cursor:
-      cursor.execute(sql)
-      row = cursor.fetchall()
-
-    result_table = pd.DataFrame(row, columns=["ticker", 'update_date', 'name_english', 'name_korea', 'market', 'price',
-                                'price_open', 'prevclose', 'price_high', 'price_low', 'volume', 'update_dt', 'create_dt']).iloc[700:750]
+    #get data from db
+    stockpricehistory_queryset = StockPriceHistory.objects.filter(
+        ticker=ticker)
+    result_dict = pd.DataFrame.from_records(
+        stockpricehistory_queryset.values())
 
     #Create graph object Figure object with data
-    fig = go.Figure(
-        data=[go.Scatter(name='ORUUM1', x=result_table['ticker'], y=result_table['prevclose']),
-              go.Scatter(name='ORUUM2', x=result_table['ticker'], y=result_table['price_high'])]
-    )
+    fig = px.line(
+        result_dict, x=result_dict['update_date'], y=result_dict['price_close'])
 
     #Update layout for graph object Figure
-    fig.update_layout(title_text='ORUUM',
-                      xaxis_title='Kind',
-                      yaxis_title='Price')
+    fig.update_layout(title_text=ticker,
+                      xaxis_title='Date',
+                      yaxis_title='Close')
 
     #Turn graph object into local plotly graph
     plotly_plot_obj = plot({'data': fig}, output_type='div')
@@ -44,78 +36,65 @@ def plot_plotly(mysql_connection):
     return plotly_plot_obj
 
 
-def dash_plotly(mysql_connection, update_date):
+def dash_plotly(ticker):
     """
     This function creates dash app for plotting variable stats by city selected
     Input: Mysql connection and city specified
     Output: Figure object
     """
-    #Create SQL command string
-    sql = """SELECT * FROM api_stock_list WHERE update_date = '{}'""".format(
-        update_date)
 
     #Get table from SQL result
-    with mysql_connection.cursor() as cursor:
-        cursor.execute(sql)
-        row = cursor.fetchall()
-
-    dash_plot_table = pd.DataFrame(row)
+    stockpricehistory_queryset = StockPriceHistory.objects.filter(
+        ticker=ticker)
+    dash_plot_table = pd.DataFrame.from_records(
+        stockpricehistory_queryset.values())
 
     #Create graph object Figure object with data
-    fig = go.Figure(data=go.Scatter(name='ORUUM' + update_date,
-                    x=dash_plot_table['ticker'], y=dash_plot_table['prevclose']))
+    fig = go.Figure(data=go.Scatter(name='ORUUM',
+                    x=dash_plot_table['update_date'], y=dash_plot_table['price_close']))
 
     #Update layout for graph object Figure
-    fig.update_layout(title_text='Variable: ' + update_date,
-                      xaxis_title='ticker',
-                      yaxis_title='prevclose')
-    #barmode='stack',
+    fig.update_layout(title_text=ticker,
+                      xaxis_title='Date',
+                      yaxis_title='Close')
+
     return fig
 
 
-#Create Mysql connection
-mysql_connection = pymysql.connect(
-    host="127.0.0.1", user='root', password='3102', db='oruum_db', cursorclass=pymysql.cursors.DictCursor)
-
-#Get plot options by running SQL query
-update_date_options_sql = "SELECT update_date FROM api_stocklist"
-
-with mysql_connection.cursor() as cursor:
-    cursor.execute(update_date_options_sql)
-    update_date_options = cursor.fetchall()
-update_date_options = [x['update_date'] for x in update_date_options]
+#GET data from database defaultly
+ticker_from_stocklist = StockPriceHistory.objects.values_list('ticker')
+ticker_from_stocklist = set(ticker_from_stocklist)
+ticker_dropdown_options = [ticker[0] for ticker in ticker_from_stocklist]
 
 #Create DjangoDash applicaiton
-app = DjangoDash(name='TickerPlot')
+app = DjangoDash(name='StockPriceHistory')
 
 #Configure app layout
 app.layout = html.Div([
     html.Div([
         #Add dropdown for option selection
         dcc.Dropdown(
-                      id='update_date',
+                      id='ticker_options',
                       options=[{'label': i, 'value': i}
-                               for i in update_date_options],
-                      value='2022-05-10')],  # Initial value for the dropdown
-             style={'width': '10%', 'margin': '0px auto'}),
+                               for i in ticker_dropdown_options],
+                      value='AAPL')],  # Initial value for the dropdown
+             style={'width': '25%', 'margin': '0px auto'}),
 
     html.Div([
-        dcc.Graph(id='update_plot',
+        dcc.Graph(id='history_plot',
                   animate=True,
                   style={"backgroundColor": "#FFF0F5"})])
 ])
 
-#Define app input and output callbacks
 
-
-@app.callback(Output('update_plot', 'figure'),  # id of html component
-              [Input('update_date', 'value')])  # id of html component
-def display_value(update_date):
+@app.callback(Output('history_plot', 'figure'),  # id of html component
+              [Input('ticker_options', 'value')])  # id of html component
+def display_value(ticker):
     """
     This function returns figure object according to value input
     Input: Value specified
     Output: Figure object
     """
     #Get city plot with input value
-    fig = dash_plotly(mysql_connection, update_date)
+    fig = dash_plotly(ticker)
     return fig

--- a/dashboard/urls.py
+++ b/dashboard/urls.py
@@ -4,9 +4,9 @@
 from django.urls import path, include
 from dashboard.views import dash_page, plotly_page
 
-app_name='dashboard'
+app_name = 'dashboard'
 
 urlpatterns = [
-    path('plotly/', plotly_page, name ="my_plotly"),
-    path('dash/', dash_page, name ="my_dash"),
+    path('plotly/<str:ticker>/', plotly_page, name="my_plotly"),
+    path('dash/', dash_page, name="my_dash"),
 ]

--- a/dashboard/views.py
+++ b/dashboard/views.py
@@ -2,26 +2,20 @@
 
 from django.shortcuts import render
 from rest_framework.decorators import api_view
-from .plotly_set import *
-from db_handler.dbModule import Database
+from .plotly_set import plot_plotly
 
 
 # Create your views here.
 @api_view(['GET'])
-def plotly_page(request):
+def plotly_page(request, ticker):
     if request.method == 'GET':
-        mysql_connection = Database().db
         #Plotly visualizations
-        target_plot = plot_plotly(mysql_connection)
-        context = {'target_plot': target_plot}
-        return render(request, "test1_dashplot.html", context=context)
+        target_plot = plot_plotly(ticker)
+        context = {'target_plot': target_plot, "ticker": ticker}
+        return render(request, "dashboard/static_dash_template.html", context=context)
 
 
 @api_view(['GET'])
 def dash_page(request):
     if request.method == 'GET':
-        #mysql_connection = Database().db
-        #Plotly visualizations
-        #target_plot = display_value("AAPL")
-        #context = {'target_plot': target_plot}
-        return render(request, "test2_dashplot.html")
+        return render(request, "dashboard/interactive_dash_template.html")

--- a/db_handler/dbModule.py
+++ b/db_handler/dbModule.py
@@ -1,13 +1,19 @@
 #  file: db_parser/dbModule.py
+import os
+import sys
+sys.path.append(os.getcwd())
 
 import pymysql
+from config import db_config
+
+
 
 
 class Database():
     def __init__(self):
         self.db = pymysql.connect(host='localhost',
                                   user='root',
-                                  password='3102',
+                                  password=db_config["password"],
                                   db='oruum_db',
                                   charset='utf8')
         self.cursor = self.db.cursor(pymysql.cursors.DictCursor)

--- a/db_handler/update_stocks_yahooapi.py
+++ b/db_handler/update_stocks_yahooapi.py
@@ -149,7 +149,7 @@ class UpdateStocksFromYahooapi:
         progress_bar.set_description("stockpricehistory from yFinance API")
 
         while (self.stockslisting_dict.empty is not True):
-            maximum_number_of_stocks_loaded_at_once = 50
+            maximum_number_of_stocks_loaded_at_once = 20
             stockslisting_dict_slice = self.stockslisting_dict.iloc[0:maximum_number_of_stocks_loaded_at_once]
 
             query_symbols = ''
@@ -169,6 +169,7 @@ class UpdateStocksFromYahooapi:
 
             self.stockslisting_dict.drop(stockslisting_dict_slice.index, inplace=True)
             self.result_json_from_yahooapi = response_from_yahooapi.json()
+            print(self.result_json_from_yahooapi)
 
             for ticker in stockslisting_dict_slice["Symbol"]:
                 try:

--- a/db_handler/update_stocks_yahooapi.py
+++ b/db_handler/update_stocks_yahooapi.py
@@ -1,6 +1,5 @@
 #  file: db_handler/update_stocks_yahooapi.py
 
-from turtle import up
 import FinanceDataReader as fdr
 import os
 import sys
@@ -197,5 +196,5 @@ class UpdateStocksFromYahooapi:
 
 if __name__ == "__main__":
     updater = UpdateStocksFromYahooapi()
-    #updater.update_stockquote_from_yahooapi("NASDAQ")
+    updater.update_stockquote_from_yahooapi("NASDAQ")
     updater.update_stockpricehistory_from_yahooapi("NASDAQ", history_range="1wk")

--- a/db_handler/update_stocks_yahooapi.py
+++ b/db_handler/update_stocks_yahooapi.py
@@ -20,17 +20,24 @@ from api.models import StockList, StockInformationHistory, StockPriceHistory
 
 
 class UpdateStocksFromYahooapi:
-    def __init__(self):
+    def __init__(self, market):
         self.database = dbModule.Database() # it is needed for handling database using raw SQL
+
+        self.stockslisting_dict = self.get_symbollist_from_financedatareader(market)
+        self.market = market
+
         self.base_url = 'https://yfapi.net'
-        self.yahoofinance_api_key = '5qYXdE6x0N768DcH5mdu76C7RlIjZI6I9wtltqbv'
+        self.yahoofinance_api_key = 'i5EPueJwqg2NEnHat9Xf82h9MI4JFiTF5pGKMy6W'
 
         '''
         yahoo api test key(for debug):
         self.yahoofinance_api_key = '5qYXdE6x0N768DcH5mdu76C7RlIjZI6I9wtltqbv' #@google 계정 api키
         self.yahoofinance_api_key = 'SWWKCLlCepeCqIA5qcICawFpEYJQeYz4YPMLmCk3' #@naver 계정 api키
-        self.yahoofinance_api_key = 'e0mzom5Zj566VYXBngUMT2s91vsViidp8SXEuoJG' #@daum 계정 api키
+        self.yahoofinance_api_key = 'i5EPueJwqg2NEnHat9Xf82h9MI4JFiTF5pGKMy6W' #@daum 계정 api키
+        '''
 
+    def get_symbollist_from_financedatareader(self, market):
+        '''
         # KRX stock symbol list
         stocks = fdr.StockListing('KRX') # 코스피, 코스닥, 코넥스 전체
         stocks = fdr.StockListing('KOSPI') # 코스피
@@ -42,10 +49,8 @@ class UpdateStocksFromYahooapi:
         stocks= fdr.StockListing('NASDAQ') # 나스닥
         stocks = fdr.StockListing('AMEX')   # 아멕스
         '''
-
-    def get_symbollist_from_financedatareader(self, market):
         symbollist_dict = fdr.StockListing(market)
-        return symbollist_dict["Symbol"]
+        return symbollist_dict
 
     def get_value_from_dict(dataframe, key, value_type='str'):
         if value_type != 'str':
@@ -60,19 +65,20 @@ class UpdateStocksFromYahooapi:
 
         return ret
 
-    def update_stockquote_from_yahooapi(self, market):
-        self.stockslisting_dict = fdr.StockListing(market)
+    def update_stockquote_from_yahooapi(self):
+        #현재 주식 가격
         url = self.base_url + "/v6/finance/quote"
 
-        progress_bar = tqdm(self.stockslisting_dict)
+        stockslisting_dict = self.stockslisting_dict.copy()
+        progress_bar = tqdm(stockslisting_dict)
         progress_bar.set_description("stocklist from yFinance API")
 
-        while (self.stockslisting_dict.empty is not True):
+        while (stockslisting_dict.empty is not True):
             maximum_number_of_stocks_loaded_at_once = 500
-            stockslisting_dict_slice = self.stockslisting_dict.iloc[0:maximum_number_of_stocks_loaded_at_once]
+            stockslisting_dict_slice = stockslisting_dict.iloc[0:maximum_number_of_stocks_loaded_at_once]
 
             query_symbols = ''
-            if market in ["KOSPI", "KOSDAQ", "KRX", "KONEX"]:
+            if self.market in ["KOSPI", "KOSDAQ", "KRX", "KONEX"]:
                 for _, value in stockslisting_dict_slice.iterrows():
                     query_symbols += value["Symbol"]+".KS,"
             else:
@@ -86,7 +92,7 @@ class UpdateStocksFromYahooapi:
             response_from_yahooapi= requests.request(
                 "GET", url, headers=headers, params=querystring)
 
-            self.stockslisting_dict.drop(stockslisting_dict_slice.index, inplace=True)
+            stockslisting_dict.drop(stockslisting_dict_slice.index, inplace=True)
             self.result_json_from_yahooapi = response_from_yahooapi.json()
 
             try:
@@ -126,7 +132,7 @@ class UpdateStocksFromYahooapi:
                                                  )
 
                     except KeyError as e:
-                        print(f"response key:{e} is not existed.\ncontinued..")
+                        print(f"response key:{e} is not existed. Continued...")
                     
                     ################################################################################
                     # progress_bar가 100%가 되지 않는데,
@@ -136,42 +142,47 @@ class UpdateStocksFromYahooapi:
                     progress_bar.update(1)
 
             except KeyError as e:
-                print(f"response에 key:{e} is not existed.\nMaybe, Yahoo API Call Limited")
-                break  # 일일 최대 호출 회수를 초과하면 request해도 response가 옳바르게 오지 않는다.
+                print(f"yFinance return is {self.result_json_from_yahooapi}. Maybe, Yahoo API Call Limited!!")
+                return  # 일일 최대 호출 회수를 초과하면 request해도 response가 제대로 오지 않는다.
 
         return
 
-    def update_stockpricehistory_from_yahooapi(self, market, history_range="1mo"):
-        self.stockslisting_dict = fdr.StockListing(market)
+    def update_stockpricehistory_from_yahooapi(self, history_range="1mo"):
         url = self.base_url + "/v8/finance/spark"
 
-        progress_bar = tqdm(self.stockslisting_dict)
+        stockslisting_dict = self.stockslisting_dict.copy()
+        print(stockslisting_dict)
+        progress_bar = tqdm(stockslisting_dict)
         progress_bar.set_description("stockpricehistory from yFinance API")
 
-        while (self.stockslisting_dict.empty is not True):
+        while (stockslisting_dict.empty is not True):
             maximum_number_of_stocks_loaded_at_once = 20
-            stockslisting_dict_slice = self.stockslisting_dict.iloc[0:maximum_number_of_stocks_loaded_at_once]
+            stockslisting_dict_slice = stockslisting_dict.iloc[0:maximum_number_of_stocks_loaded_at_once]
 
             query_symbols = ''
-            if market in ["KOSPI", "KOSDAQ", "KRX", "KONEX"]:
+            if self.market in ["KOSPI", "KOSDAQ", "KRX", "KONEX"]:
                 for _, value in stockslisting_dict_slice.iterrows():
                     query_symbols += value["Symbol"]+".KS,"
             else:
                 for _, value in stockslisting_dict_slice.iterrows():
                     query_symbols += value["Symbol"]+","
 
-            tick_interval="1d" #1day
+            tick_interval="1d" #interval is 1-day
             querystring = {"symbols": query_symbols
                         ,"range": history_range
                         ,"interval": tick_interval}
             headers = {'x-api-key': self.yahoofinance_api_key}
             response_from_yahooapi= requests.request("GET", url, headers=headers, params=querystring)
 
-            self.stockslisting_dict.drop(stockslisting_dict_slice.index, inplace=True)
+            stockslisting_dict.drop(stockslisting_dict_slice.index, inplace=True)
             self.result_json_from_yahooapi = response_from_yahooapi.json()
-            print(self.result_json_from_yahooapi)
 
-            for ticker in stockslisting_dict_slice["Symbol"]:
+            for result_iterator in self.result_json_from_yahooapi.values():
+                try:
+                    ticker = result_iterator["symbol"]
+                except TypeError as e:
+                    print(f"yFinance return is {result_iterator}. Maybe, Yahoo API Call Limited!!")
+                    return # 일일 최대 호출 회수를 초과하면 request해도 response가 제대로 오지 않는다.
                 try:
                     object_from_stocklist = StockList.objects.get(ticker=ticker)
                     for price_close, timestamp in zip(self.result_json_from_yahooapi[ticker]['close'], self.result_json_from_yahooapi[ticker]['timestamp']):
@@ -189,13 +200,13 @@ class UpdateStocksFromYahooapi:
                                                         ,price_close = price_close)
 
                 except StockList.DoesNotExist:
-                    print(f"stocklist에 등록되지 않은 {ticker} 종목입니다.\nstocklist에 먼저 추가해주세요.")
+                    print(f"{ticker} 종목은 'api_stocklist'에 등록되지 않았네요. Continued...")
                 
                 progress_bar.update(1)
 
         return
 
 if __name__ == "__main__":
-    updater = UpdateStocksFromYahooapi()
-    updater.update_stockquote_from_yahooapi("NASDAQ")
-    updater.update_stockpricehistory_from_yahooapi("NASDAQ", history_range="1wk")
+    updater = UpdateStocksFromYahooapi("NASDAQ")
+    updater.update_stockquote_from_yahooapi()
+    updater.update_stockpricehistory_from_yahooapi(history_range="1mo")

--- a/templates/dashboard/interactive_dash_template.html
+++ b/templates/dashboard/interactive_dash_template.html
@@ -9,12 +9,8 @@
 </head>
 
 <body>
-    <p>
-        <center>TEST-DASH</center>
         {%load plotly_dash%}
-        {%plotly_app name="TickerPlot"%}
-    </p>
-
+        {%plotly_app name="StockPriceHistory"%}
 </body>
 
 </html>

--- a/templates/dashboard/static_dash_template.html
+++ b/templates/dashboard/static_dash_template.html
@@ -10,7 +10,7 @@
 
 <body>
     <p>
-        <center>TEST-DASH</center>
+        <center>{{ticker}}</center>
         {{target_plot|safe}}
     </p>
 </body>


### PR DESCRIPTION
## 풀리퀘스트(PR): 변경범위 [database, dashboard]
### 1. oruum database 중 종목들의 일일 주가 정보를 담는 데이터베이스를 업데이트 하기 위한 코드를 작성하였습니다.

  - yahoo API 를 이용하여, 기간별로 1일 간격으로 database를 업데이트하는 코드입니다.
  - update_stocks_yahooapi.py 내 `update_stockpricehistory_from_yahooapi` 함수를 참고해주세요.
  - database 업데이트 후, stockpricehistory API 호출 결과
![image](https://user-images.githubusercontent.com/19821690/169644871-296e1544-476d-4b93-8289-6c2656292d96.png)

---

### 2. dashboard 관련하여 plotly-dash 를 이용하여 구현하였어요.
  - 조만간, oruum 디자인 스킨이 더해진 frontend의 멋진 dashboard를 구현될 예정인데요
  - 그 전에, 간단하게 만들 수 있는 dashboard 기능을 더해봤어요.
  - stockpricehistory 데이터베이스에서 종목명을 집으면 대쉬보드에서 차트가 표출됩니다.
  
![image](https://user-images.githubusercontent.com/19821690/169658660-21ed0210-f678-484c-9a55-3fcc3357eb25.png)
![image](https://user-images.githubusercontent.com/19821690/169658652-9c21948e-b8ea-4eb2-9bb7-d19bb26cc660.png)
